### PR TITLE
ros2_intel_movidius_ncs: 0.3.0-0 in 'ardent/distribution.yaml' [bloom]

### DIFF
--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -611,6 +611,27 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
+  ros2_intel_movidius_ncs:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_intel_movidius_ncs.git
+      version: 0.3.0
+    release:
+      packages:
+      - movidius_ncs_example
+      - movidius_ncs_image
+      - movidius_ncs_launch
+      - movidius_ncs_lib
+      - movidius_ncs_stream
+      tags:
+        release: release/ardent/{package}/{version}
+      url: https://github.com/chaoli2/ros2_intel_movidius_ncs-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/intel/ros2_intel_movidius_ncs.git
+      version: 0.3.0
+    status: maintained
   ros2cli:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_intel_movidius_ncs` to `0.3.0-0`:

- upstream repository: https://github.com/intel/ros2_intel_movidius_ncs.git
- release repository: https://github.com/chaoli2/ros2_intel_movidius_ncs-release.git
- distro file: `ardent/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
