### PR TITLE
ros2_object_msgs: 0.3.0-0 in 'ardent/distribution.yaml' [bloom]

### DIFF
--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -611,6 +611,23 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
+  ros2_object_msgs:
+    doc:
+      type: git
+      url: https://github.com/chaoli2/ros2_object_msgs.git
+      version: 0.3.0
+    release:
+      packages:
+      - object_msgs
+      tags:
+        release: release/ardent/{package}/{version}
+      url: https://github.com/chaoli2/ros2_object_msgs-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/chaoli2/ros2_object_msgs.git
+      version: 0.3.0
+    status: maintained
   ros2cli:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_object_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/chaoli2/ros2_object_msgs.git
- release repository: https://github.com/chaoli2/ros2_object_msgs-release.git
- distro file: `ardent/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
